### PR TITLE
Dotenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,10 @@
+# process.env vars set based on NODE_ENV setting, in this order: (see env.js)
+#   1. .env                                     - loaded first
+#   2. .env.[development|test|production]       - Environment-specific settings.
+#   3. .env.local                               - Local overrides. This file is loaded for all environments except test.
+#   4. .env.[development|test|production].local - Local overrides of environment-specific settings.
+#   5. environment variables                    - never overwritten
+
 KRAKEN_URL = https://api.kraken.com/0/public/Ticker?pair=XETHZ
 BITSTAMP_URL = https://www.bitstamp.net/api/v2/ticker/ETH
 GDAX_URL = https://api.gdax.com//products/ETH-

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+KRAKEN_URL = https://api.kraken.com/0/public/Ticker?pair=XETHZ
+BITSTAMP_URL = https://www.bitstamp.net/api/v2/ticker/ETH
+GDAX_URL = https://api.gdax.com//products/ETH-

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,0 @@
-{
-  "krakenURL": "https://api.kraken.com/0/public/Ticker?pair=XETHZ",
-  "bitstampURL": "https://www.bitstamp.net/api/v2/ticker/ETH",
-  "gdaxURL": "https://api.gdax.com//products/ETH-"
-}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test": "test"
     },
     "dependencies": {
-        "config": "1.30.0",
+        "dotenv": "5.0.1",
         "fetch": "1.1.0",
         "truffle-contract": "3.0.3",
         "web3": "1.0.0-beta.30"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "test": "test"
     },
     "dependencies": {
+        "cross-env": "5.1.3",
         "dotenv": "5.0.1",
         "fetch": "1.1.0",
         "truffle-contract": "3.0.3",
@@ -17,8 +18,8 @@
         "mocha": "5.0.1"
     },
     "scripts": {
-        "start": "node ./src/runFeeder.js",
-        "test": "mocha --timeout 10000",
+        "start": "cross-env NODE_ENV=development node ./src/runFeeder.js",
+        "test": "cross-env NODE_ENV=test mocha --timeout 10000",
         "contracts:migrate": "cd augmint-contracts && yarn migrate",
         "ganache:run": "cd augmint-contracts && yarn ganache:run",
         "contracts:runmigrate": "cd augmint-contracts && yarn runmigrate"

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -9,6 +9,7 @@ let decimalsDiv;
 let accounts;
 let augmintRatesInstance;
 let augmintTokenInstance;
+
 module.exports = {
     get decimalsDiv() {
         return decimalsDiv;
@@ -35,7 +36,7 @@ const AugmintToken = require("../augmint-contracts/build/contracts/TokenAEur.jso
 const contract = require("truffle-contract");
 
 // config paramaters for exchange data (real exchange rates and simulated rates)
-const config = require("config");
+require("dotenv").config();
 
 const Web3 = require("web3");
 const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
@@ -57,7 +58,7 @@ if (typeof augmintRates.currentProvider.sendAsync !== "function") {
 // get ETH/CCY price  from Kraken Exchange
 function getKrakenPrice(CCY) {
     return new Promise(function(resolve, reject) {
-        fetch.fetchUrl(config.krakenURL + CCY, (error, m, b) => {
+        fetch.fetchUrl(process.env.KRAKEN_URL + CCY, (error, m, b) => {
             if (error) {
                 reject(new Error("Can't get price from Kraken.\n " + error));
             } else {
@@ -73,7 +74,7 @@ function getKrakenPrice(CCY) {
 // get ETH/CCY price  from BitStamp Exchange
 function getBitstampPrice(CCY) {
     return new Promise(function(resolve, reject) {
-        fetch.fetchUrl(config.bitstampURL + CCY, (error, m, b) => {
+        fetch.fetchUrl(process.env.BITSTAMP_URL + CCY, (error, m, b) => {
             if (error) {
                 reject(new Error("Can't get price from BitStamp.\n " + error));
             } else {
@@ -89,7 +90,7 @@ function getBitstampPrice(CCY) {
 // get ETH/CCY price  from BitStamp Exchange
 function getGdaxPrice(CCY) {
     return new Promise(function(resolve, reject) {
-        fetch.fetchUrl(config.gdaxURL + CCY + "/ticker", (error, m, b) => {
+        fetch.fetchUrl(process.env.GDAX_URL + CCY + "/ticker", (error, m, b) => {
             if (error) {
                 reject(new Error("Can't get price from BitStamp.\n " + error));
             } else {

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -6,7 +6,7 @@
 */
 
 // config paramaters from .env for exchange data (real exchange rates and simulated rates)
-require("dotenv").config();
+require("./env.js");
 const Web3 = require("web3");
 const fetch = require("fetch");
 const AugmintRates = require("../augmint-contracts/build/contracts/Rates.json");

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -5,6 +5,14 @@
 * ...
 */
 
+// config paramaters from .env for exchange data (real exchange rates and simulated rates)
+require("dotenv").config();
+const Web3 = require("web3");
+const fetch = require("fetch");
+const AugmintRates = require("../augmint-contracts/build/contracts/Rates.json");
+const AugmintToken = require("../augmint-contracts/build/contracts/TokenAEur.json");
+const contract = require("truffle-contract");
+
 let decimalsDiv;
 let accounts;
 let augmintRatesInstance;
@@ -30,15 +38,6 @@ module.exports = {
     updatePrice
 };
 
-const fetch = require("fetch");
-const AugmintRates = require("../augmint-contracts/build/contracts/Rates.json");
-const AugmintToken = require("../augmint-contracts/build/contracts/TokenAEur.json");
-const contract = require("truffle-contract");
-
-// config paramaters for exchange data (real exchange rates and simulated rates)
-require("dotenv").config();
-
-const Web3 = require("web3");
 const web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 
 // Truffle abstraction to interact with our deployed contract

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,42 @@
+/*
+    set process.env vars from .env files, based on NODE_ENV setting, in this order:
+    1. .env                                     - loadded first
+    2. .env.[development|test|production]       - Environment-specific settings.
+    3. .env.local                               - Local overrides. This file is loaded for all environments except test.
+    4. .env.[development|test|production].local - Local overrides of environment-specific settings.
+    5. environment variables                    - never overwritten
+*/
+"use strict";
+
+const fs = require("fs");
+const dotenvConfig = require("dotenv").config;
+const DOTENV_PATH = ".env";
+const NODE_ENV = process.env.NODE_ENV;
+
+if (!NODE_ENV) {
+    throw new Error("The NODE_ENV environment variable is required but was not specified.");
+}
+
+// https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
+const dotenvFiles = [
+    `${DOTENV_PATH}.${NODE_ENV}.local`,
+    `${DOTENV_PATH}.${NODE_ENV}`,
+    // Don't include `.env.local` for `test` environment since normally you expect tests to produce the same results for everyone
+    NODE_ENV !== "test" && `${DOTENV_PATH}.local`,
+    DOTENV_PATH // the base .env
+].filter(Boolean);
+
+// Load environment variables from .env* files. Suppress warnings using silent if this file is missing.
+// dotenv will never modify any environment variables that have already been set. https://github.com/motdotla/dotenv
+dotenvFiles.forEach(dotenvFile => {
+    if (fs.existsSync(dotenvFile)) {
+        dotenvConfig({
+            path: dotenvFile
+        });
+        // require("dotenv").config({
+        //     path: dotenvFile
+        // });
+    }
+});
+
+console.log(process.env.NODE_ENV, process.env.KRAKEN_URL);

--- a/test/ratesfeeder.js
+++ b/test/ratesfeeder.js
@@ -6,12 +6,12 @@ describe("RatesFeeder: real exchange rate tests", function() {
         const price = await ratesFeeder.getKrakenPrice("EUR");
         assert.equal("number", typeof price);
     });
-    /*
-    it('BitStamp interface should return a number', async function () {
+
+    it.skip("BitStamp interface should return a number", async function() {
         const price = await ratesFeeder.getBitstampPrice("EUR");
-        assert.equal('number', typeof price);
+        assert.equal("number", typeof price);
     });
-    */
+
     it("Gdax interface should return a number", async function() {
         const price = await ratesFeeder.getGdaxPrice("EUR");
         assert.equal("number", typeof price);

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,13 +282,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-config@1.30.0:
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/config/-/config-1.30.0.tgz#1d60a9f35348a13c175798d384e81a5a16c3ba6e"
-  dependencies:
-    json5 "0.4.0"
-    os-homedir "1.0.2"
-
 content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
@@ -487,6 +480,10 @@ diffie-hellman@^5.0.0:
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
+dotenv@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -986,10 +983,6 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
-json5@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
-
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
@@ -1181,10 +1174,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
-
-os-homedir@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
 p-cancelable@^0.3.0:
   version "0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -336,6 +336,21 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@3.x.x:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
@@ -944,9 +959,17 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -1008,6 +1031,13 @@ keccakjs@^0.2.1:
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 make-dir@^1.0.0:
   version "1.2.0"
@@ -1273,6 +1303,10 @@ proxy-addr@~2.0.2:
     forwarded "~0.1.2"
     ipaddr.js "1.6.0"
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
 psl@^1.1.7:
   version "1.1.24"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.24.tgz#06c70e9c5145b72ed888b318a21f719d1823512b"
@@ -1475,6 +1509,16 @@ sha3@^1.1.0:
   resolved "https://registry.yarnpkg.com/sha3/-/sha3-1.2.0.tgz#6989f1b70a498705876a373e2c62ace96aa9399a"
   dependencies:
     nan "^2.0.5"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 simple-concat@^1.0.0:
   version "1.0.0"
@@ -1956,6 +2000,12 @@ web3@^0.20.1:
     typedarray-to-buffer "^3.1.2"
     yaeti "^0.0.6"
 
+which@^1.2.9:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -2010,6 +2060,10 @@ xtend@^4.0.0:
 yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yauzl@^2.4.2:
   version "2.9.1"


### PR DESCRIPTION
- setting process.env using dotenv 
- set NODE_ENV in yarn scripts using cross-env
- added support to  .env.local, .env.<NODE_ENV> and .env.<NODE_ENV>.local via env.js for future use in builds/tests/local dev.  
  See env.js & approach in similar [ruby gem](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use)