### PR TITLE
Rinkeby scheduling

### DIFF
--- a/.env
+++ b/.env
@@ -25,3 +25,6 @@ ETHEREUM_ACCOUNT = 0x76E7a0aEc3E43211395bBBB6Fa059bD6750F83c3
 
 # NEVER COMMIT PRIVATE KEYS of real accounts!!! NB: make sure you have a leading 0x
 ETHEREUM_PRIVATE_KEY = 0x85b3d743fbe4ec4e2b58947fa5484da7b2f5538b0ae8e655646f94c95d5fb949
+
+# exit after n th confirmation after sending tx (max 12). Keep it 0 for ganache tests
+SUCCESS_AFTER_N_CONFIRMATION = 0

--- a/.env
+++ b/.env
@@ -11,9 +11,9 @@ GDAX_URL = https://api.gdax.com//products/ETH-
 
 # valid values: http, websocket
 PROVIDER_TYPE = http
+# infura: https://rinkeby.infura.io/ (with trailing slash) or ws://rinkeby.infura.io/ws
+# local: http://localhost:8545 or ws://localhost:8545
 
-# infura: https://rinkeby.infura.io/ (with trailing slash) or wss://rinkeby.infura.io/ws
-# local: http://localhost:8545 or wss://localhost:8545
 PROVIDER_URL = http://localhost:8545
 
 # NB: infura doesn't require API keys currently to WSS so don't need API KEY to be set if using infura websocket

--- a/.env
+++ b/.env
@@ -10,11 +10,11 @@ BITSTAMP_URL = https://www.bitstamp.net/api/v2/ticker/ETH
 GDAX_URL = https://api.gdax.com//products/ETH-
 
 # valid values: http, websocket
-PROVIDER_TYPE = http
+PROVIDER_TYPE = websocket
+
 # infura: https://rinkeby.infura.io/ (with trailing slash) or ws://rinkeby.infura.io/ws
 # local: http://localhost:8545 or ws://localhost:8545
-
-PROVIDER_URL = http://localhost:8545
+PROVIDER_URL = ws://localhost:8545
 
 # NB: infura doesn't require API keys currently to WSS so don't need API KEY to be set if using infura websocket
 # INFURA_API_KEY = <NEVER COMMIT API KEYS! Set it in .env.local or as env variable>

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
         "mocha": "5.0.3"
     },
     "scripts": {
-        "start": "cross-env NODE_ENV=development node ./src/runFeeder.js",
-        "start:production":
+        "start":
+            "echo 'This app does not have a start feature (for now). Run (or schedule): yarn updaterates[:production]'",
+        "updaterates": "cross-env NODE_ENV=development node ./src/runFeeder.js",
+        "updaterates:production":
             "cross-env NODE_ENV=production node ./src/runFeeder.js",
         "test": "cross-env NODE_ENV=test mocha --timeout 10000",
         "contracts:migrate": "cd augmint-contracts && yarn migrate",

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -23,6 +23,7 @@ let augmintRatesWeb3Contract; // need to use this instad of truffle-contract for
 let augmintTokenInstance;
 const account = process.env.ETHEREUM_ACCOUNT;
 const SET_RATE_GAS = 60000;
+const SUCCESS_AFTER_N_CONFIRMATION = parseInt(process.env.SUCCESS_AFTER_N_CONFIRMATION);
 
 module.exports = {
     get isInitialised() {
@@ -65,7 +66,9 @@ console.log(
     PROVIDER_URL: ${process.env.PROVIDER_URL}
     INFURA_API_KEY: ${process.env.INFURA_API_KEY ? "[secret]" : "not provided"}
     ETHEREUM_ACCOUNT: ${process.env.ETHEREUM_ACCOUNT}
-    ETHEREUM_PRIVATE_KEY: ${process.env.ETHEREUM_PRIVATE_KEY ? "[secret]" : "not provided"}`
+    ETHEREUM_PRIVATE_KEY: ${process.env.ETHEREUM_PRIVATE_KEY ? "[secret]" : "not provided"}
+    SUCCESS_AFTER_N_CONFIRMATION: ${process.env.SUCCESS_AFTER_N_CONFIRMATION}
+    `
 );
 
 async function init() {
@@ -186,6 +189,12 @@ async function getPrice(CCY) {
 
 function onSetRateTxConfirmations(confirmationNumber, receipt) {
     console.log(`  Confirmation #${confirmationNumber} received. txhash: ${receipt.transactionHash}`);
+    if (confirmationNumber >= SUCCESS_AFTER_N_CONFIRMATION) {
+        console.log(
+            ` setRate tx success, exiting. Received ${confirmationNumber}. confirmation (defined by SUCCESS_AFTER_N_CONFIRMATION)`
+        );
+        process.exit(0);
+    }
 }
 
 /* Update price on chain.


### PR DESCRIPTION
quick fixes for heroku deploy:

- added SUCCES_AFTER_N_CONFIRMATION param
- refactored launching script logic to work with heroku defaults. Heroku calls `yarn start` for each deploy, so changed it to do nothing. We schedule a `yarn updaterates:production` instead
- default is WS in .env (for local tests, it works fine with ganache)