### PR TITLE
Logging fixes & tweaks

### DIFF
--- a/.env
+++ b/.env
@@ -46,6 +46,9 @@ CHECK_TICKER_PRICE_INTERVAL = 5000
 # in % (i.e. 1 = 1%)
 LIVE_PRICE_THRESHOLD_PT = 0.05
 
+# log success with LOG level after how many confirmation
+LOG_AS_SUCCESS_AFTER_N_CONFIRMATION = 3
+
 ####################################################
 ######### Status API settings
 ####################################################

--- a/.env
+++ b/.env
@@ -44,7 +44,7 @@ CHECK_TICKER_PRICE_INTERVAL = 5000
 
 # when to update Augmint rate? A rate update tx will be sent to chain if live ticker price (avg) is lower/higher by this % than current Augmint rate
 # in % (i.e. 1 = 1%)
-LIVE_PRICE_THRESHOLD_PT = 1
+LIVE_PRICE_THRESHOLD_PT = 0.05
 
 ####################################################
 ######### Status API settings

--- a/.env.production
+++ b/.env.production
@@ -4,7 +4,7 @@
 ######### Global settings
 ####################################################
 # see https://ulog.js.org/ modules: ratesFeeder, WebsocketTicker, statusApi
-LOG = INFO
+LOG = LOG
 
 ####################################################
 ######### ratesFeeder settings
@@ -35,7 +35,7 @@ CHECK_TICKER_PRICE_INTERVAL = 30000
 
 # when to update Augmint rate? A rate update tx will be sent to chain if live ticker price (avg) is lower/higher by this % than current Augmint rate
 # in % (i.e. 1 = 1%)
-LIVE_PRICE_THRESHOLD_PT = 3
+LIVE_PRICE_THRESHOLD_PT = 2
 
 ####################################################
 ######### Status API settings

--- a/.env.production
+++ b/.env.production
@@ -37,6 +37,9 @@ CHECK_TICKER_PRICE_INTERVAL = 30000
 # in % (i.e. 1 = 1%)
 LIVE_PRICE_THRESHOLD_PT = 2
 
+# log success with LOG level after how many confirmation
+LOG_AS_SUCCESS_AFTER_N_CONFIRMATION = 12
+
 ####################################################
 ######### Status API settings
 ####################################################

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -52,7 +52,6 @@ class RatesFeeder {
         ["SIGINT", "SIGHUP", "SIGTERM"].forEach(signal => process.on(signal, signal => this.exit(signal)));
 
         this.account = process.env.ETHEREUM_ACCOUNT;
-        this.currentAugmintRate = {};
 
         log.info(
             // IMPORTANT: NEVER expose keys even not in logs!
@@ -146,7 +145,7 @@ class RatesFeeder {
         log.debug(
             `    checkTickerPrice() currentAugmintRate[${CCY}]: ${
                 currentAugmintRate.price
-            } livePrice: ${livePrice} livePriceDifference: ${livePriceDifference * 100} %`
+            } livePrice: ${livePrice} livePriceDifference: ${(livePriceDifference * 100).toFixed(2)} %`
         );
 
         const tickersInfo = this.tickers.map(t => ({ name: t.name, lastTrade: t.lastTrade }));
@@ -237,8 +236,8 @@ class RatesFeeder {
 
             log.debug(
                 `==> updatePrice() nonce: ${nonce} sending setRate(${currency}, ${priceToSend}). currentAugmintRate[${CCY}]: ${
-                    this.currentAugmintRate[CCY] ? this.currentAugmintRate[CCY].price : "null"
-                } livePrice: ${this.livePrice}`
+                    this.lastTickerCheckResult[CCY] ? this.lastTickerCheckResult[CCY].currentAugmintRate.price : "null"
+                } livePrice: ${this.lastTickerCheckResult[CCY] ? this.lastTickerCheckResult[CCY].livePrice : "null"}`
             );
 
             const tx = this.web3.eth.sendSignedTransaction(signedTx.rawTransaction);
@@ -259,9 +258,7 @@ class RatesFeeder {
                         log.log(
                             `    \u2713 updatePrice() nonce: ${nonce}  txHash: ${
                                 receipt.transactionHash
-                            } mined: setRate(${currency}, ${priceToSend}). Previous Augmint rate: ${
-                                this.currentAugmintRate[CCY].price
-                            }`
+                            } confirmed: setRate(${currency}, ${priceToSend}) - received ${confirmationNumber} confirmations  `
                         );
                     } else {
                         log.debug(

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -27,7 +27,6 @@ const Rates = require("./abiniser/abis/Rates_ABI_73a17ebb0acc71773371c6a8e1c8e6c
 
 const CCY = "EUR"; // only EUR is suported by WebsocketTicker providers ATM
 const SET_RATE_GAS_LIMIT = 80000;
-const LOG_AS_SUCCESS_AFTER_N_CONFIRMATION = 12;
 
 class RatesFeeder {
     constructor(tickers) {
@@ -66,6 +65,7 @@ class RatesFeeder {
             SETRATE_TX_TIMEOUT: ${process.env.SETRATE_TX_TIMEOUT}
             CHECK_TICKER_PRICE_INTERVAL: ${process.env.CHECK_TICKER_PRICE_INTERVAL}
             LOG: ${process.env.LOG} (log.level: ${log.level})
+            LOG_AS_SUCCESS_AFTER_N_CONFIRMATION: ${process.env.LOG_AS_SUCCESS_AFTER_N_CONFIRMATION}
             Ticker providers: ${this.tickerNames}`
         );
 
@@ -234,7 +234,7 @@ class RatesFeeder {
                 this.web3.eth.getTransactionCount(this.account)
             ]);
 
-            log.debug(
+            log.log(
                 `==> updatePrice() nonce: ${nonce} sending setRate(${currency}, ${priceToSend}). currentAugmintRate[${CCY}]: ${
                     this.lastTickerCheckResult[CCY] ? this.lastTickerCheckResult[CCY].currentAugmintRate.price : "null"
                 } livePrice: ${this.lastTickerCheckResult[CCY] ? this.lastTickerCheckResult[CCY].livePrice : "null"}`
@@ -254,7 +254,7 @@ class RatesFeeder {
                     );
                 })
                 .on("confirmation", (confirmationNumber, receipt) => {
-                    if (confirmationNumber === LOG_AS_SUCCESS_AFTER_N_CONFIRMATION) {
+                    if (confirmationNumber === parseInt(process.env.LOG_AS_SUCCESS_AFTER_N_CONFIRMATION)) {
                         log.log(
                             `    \u2713 updatePrice() nonce: ${nonce}  txHash: ${
                                 receipt.transactionHash


### PR DESCRIPTION
- default log level adj in production to log setRate tx success
- LIVE_PRICE_THRESHOLD_PT to 2% in prod & to low in local for testing
- LOG_AS_SUCCESS_AFTER_N_CONFIRMATION param to env (default 12 in prod, 3 in local test)