### PR TITLE
Housekeeping + status finessing

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,13 @@
 # settings for tests
 
+# see https://ulog.js.org/  modules: ratesFeeder, WebsocketTicker, statusApi
+LOG = ERROR
+
 # how often compare live ticker prices to decide if Augmint on chain price needs to be updated (in ms). Set to 0 to disable (for tests)
 #    NB: ticker prices in state & updated "instantly" each time a trade made on the exchange (via websocket subscriptions )
 CHECK_TICKER_PRICE_INTERVAL = 0
+
+
+# when to update Augmint rate? A rate update tx will be sent to chain if live ticker price (avg) is lower/higher by this % than current Augmint rate
+# in % (i.e. 1 = 1%)
+LIVE_PRICE_THRESHOLD_PT = 2

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -162,7 +162,7 @@ class RatesFeeder {
                 } livePrice: ${livePrice} livePriceDifference: ${(livePriceDifference * 100).toFixed(2)} %`
             );
 
-            const tickersInfo = this.tickers.map(t => ({ name: t.name, lastTicker: t.lastTicker }));
+            const tickersInfo = this.tickers.map(t => t.getStatus());
             this.lastTickerCheckResult.checkedAt = new Date();
             this.lastTickerCheckResult[CCY] = {
                 currentAugmintRate,

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -23,7 +23,7 @@ const contractsHelper = require("./contractsHelper.js");
 const TokenAEur = require("./abiniser/abis/TokenAEur_ABI_2ea91d34a7bfefc8f38ef0e8a5ae24a5.json");
 const Rates = require("./abiniser/abis/Rates_ABI_73a17ebb0acc71773371c6a8e1c8e6ce.json");
 
-const CCY = "EUR"; // only EUR is suported by WebsocketTicker providers ATM
+const CCY = "EUR"; // only EUR is suported by TickerProvider providers ATM
 const SET_RATE_GAS_LIMIT = 80000;
 
 const median = values => {
@@ -42,7 +42,7 @@ const median = values => {
 
 class RatesFeeder {
     constructor(tickers) {
-        this.tickers = tickers; // array of WebsocketTicker objects
+        this.tickers = tickers; // array of TickerProvider objects
         // list of tickernames:
         this.tickerNames = this.tickers.reduce(
             (accum, ticker, idx) => (idx == 0 ? ticker.name : accum + ", " + ticker.name),

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -144,8 +144,8 @@ class RatesFeeder {
             log.debug(
                 "    ",
                 t.name,
-                t.lastTrade ? t.lastTrade.price : "null",
-                t.lastTrade ? t.lastTrade.time : "null"
+                t.lastTicker ? t.lastTicker.price : "null",
+                t.lastTicker ? t.lastTicker.time : "null"
             );
         });
 
@@ -162,7 +162,7 @@ class RatesFeeder {
                 } livePrice: ${livePrice} livePriceDifference: ${(livePriceDifference * 100).toFixed(2)} %`
             );
 
-            const tickersInfo = this.tickers.map(t => ({ name: t.name, lastTrade: t.lastTrade }));
+            const tickersInfo = this.tickers.map(t => ({ name: t.name, lastTicker: t.lastTicker }));
             this.lastTickerCheckResult.checkedAt = new Date();
             this.lastTickerCheckResult[CCY] = {
                 currentAugmintRate,
@@ -208,8 +208,8 @@ class RatesFeeder {
     calculateAugmintPrice(tickers) {
         // ignore 0 or null prices (exchange down or no price info yet)
         const prices = tickers
-            .filter(ticker => ticker.lastTrade && ticker.lastTrade.price > 0)
-            .map(t => t.lastTrade.price);
+            .filter(ticker => ticker.lastTicker && ticker.lastTicker.price > 0)
+            .map(t => t.lastTicker.price);
         let augmintPrice = median(prices);
         augmintPrice = Math.round(augmintPrice * this.decimalsDiv) / this.decimalsDiv;
 

--- a/src/runFeeder.js
+++ b/src/runFeeder.js
@@ -20,27 +20,27 @@ ratesFeeder
     .then(() => {
         subscribeTickers.connectAll();
 
-        subscribeTickers.tickers.forEach(ticker => {
-            // ticker.on("pricechange", onTickerPriceChange);
-            // ticker.on("trade", onTickerTrade);
-            // ticker.on("disconnecting", onTickerDisconnecting);
-            ticker.on("heartbeattimeout", onTickerHeartbeatTimeout);
+        subscribeTickers.tickers.forEach(tickerProvider => {
+            // tickerProvider.on("pricechange", onTickerPriceChange);
+            // tickerProvider.on("trade", onTickerTrade);
+            // tickerProvider.on("disconnecting", onTickerDisconnecting);
+            tickerProvider.on("heartbeattimeout", onTickerHeartbeatTimeout);
         });
 
-        // function onTickerDisconnecting(ticker) {
-        //     log.debug(ticker.name, "disconnecting.", "WebSocket readyState: ", this.ws.readyState);
+        // function onTickerDisconnecting(tickerProvider) {
+        //     log.debug(tickerProvider.name, "disconnecting.", "WebSocket readyState: ", tickerProvider.ws.readyState);
         // }
 
         function onTickerHeartbeatTimeout(ticker) {
             log.warn(ticker.name, "heartbeat timed out. Reconnecting.");
         }
 
-        // function onTickerPriceChange(lastTrade, prevTrade, ticker) {
-        //     log.log("onTickerPriceChange", ticker.name, "\t", JSON.stringify(lastTrade), JSON.stringify(prevTrade));
+        // function onTickerPriceChange(newTicker, prevTicker, ticker) {
+        //     log.log("onTickerPriceChange", ticker.name, "\t", JSON.stringify(newTicker), JSON.stringify(prevTicker));
         // }
         //
-        // function onTickerTrade(lastTrade, prevTrade, ticker) {
-        //     log.debug("onTickerTrade", ticker.name, "\t", JSON.stringify(lastTrade), JSON.stringify(prevTrade));
+        // function onTickerTrade(newTicker, prevTicker, tickerProvider) {
+        //     log.debug("onTickerTrade", tickerProvider.name, "\t", JSON.stringify(newTicker), JSON.stringify(prevTicker));
         // }
     })
     .catch(error => {

--- a/src/subscribeTickers.js
+++ b/src/subscribeTickers.js
@@ -2,7 +2,7 @@
  - write integration tests
   */
 
-const WebsocketTicker = require("./tickerProviders/WebsocketTicker.js");
+const TickerProvider = require("./tickerProviders/TickerProvider.js");
 
 const gdaxTickerProvider = require("./tickerProviders/gdaxTickerProvider.js");
 const krakenTickerProvider = require("./tickerProviders/krakenTickerProvider.js");
@@ -11,10 +11,10 @@ const bitstampTickerProvider = require("./tickerProviders/bitstampTickerProvider
 //const bitfinexTickerProvider = require("./tickerProviders/bitfinexTickerProvider.js");
 
 const tickers = [
-    new WebsocketTicker(krakenTickerProvider.definition),
-    new WebsocketTicker(gdaxTickerProvider.definition),
-    new WebsocketTicker(bitstampTickerProvider.definition)
-    //,    new WebsocketTicker(bitfinexTickerProvider.definition)
+    new TickerProvider(krakenTickerProvider.definition),
+    new TickerProvider(gdaxTickerProvider.definition),
+    new TickerProvider(bitstampTickerProvider.definition)
+    //,    new TickerProvider(bitfinexTickerProvider.definition)
 ];
 
 function connectAll() {

--- a/src/tickerProviders/TickerProvider.js
+++ b/src/tickerProviders/TickerProvider.js
@@ -138,6 +138,10 @@ class TickerProvider extends EventEmitter {
         }
     }
 
+    getStatus() {
+        return { name: this.name, lastTicker: this.lastTicker, lastHeartbeat: this.lastHeartbeat };
+    }
+
     connectAndSubscribe() {
         try {
             if (!this.isDisconnecting) {

--- a/src/tickerProviders/TickerProvider.js
+++ b/src/tickerProviders/TickerProvider.js
@@ -79,6 +79,8 @@ class TickerProvider extends EventEmitter {
         this.lastHeartbeat = null;
         this.name = definition.NAME;
         this.lastTicker = null; // { price, volume, time}
+        this.connectedAt = null;
+        this.reconnectCount = null; // first connect will set to 0, any further connect increases
 
         // if standard websocket connection
         this.wssUrl = definition.WSS_URL;
@@ -139,7 +141,13 @@ class TickerProvider extends EventEmitter {
     }
 
     getStatus() {
-        return { name: this.name, lastTicker: this.lastTicker, lastHeartbeat: this.lastHeartbeat };
+        return {
+            name: this.name,
+            lastTicker: this.lastTicker,
+            lastHeartbeat: this.lastHeartbeat,
+            connectedAt: this.connectedAt,
+            reconnectCount: this.reconnectCount
+        };
     }
 
     connectAndSubscribe() {
@@ -290,6 +298,12 @@ class TickerProvider extends EventEmitter {
 
     _onProviderConnected(data) {
         log.debug(this.name, "connected.", JSON.stringify(data));
+        this.connectedAt = new Date();
+        if (this.reconnectCount) {
+            this.reconnectCount++;
+        } else {
+            this.reconnectCount = 0; // first connect
+        }
         if (this.pingInterval && !this.isDisconnecting) {
             this.pingIntervalTimer = setInterval(this.ping.bind(this), this.pingInterval);
         }

--- a/src/tickerProviders/TickerProvider.js
+++ b/src/tickerProviders/TickerProvider.js
@@ -1,4 +1,4 @@
-/* Generic class to handle websocket info from exchanges
+/* Generic class to handle ticker info from exchanges (websocket or pusher)
 
 maintains lastTicker as: {price, volume, time, tradeId}
 depending on ticker provider implementation it updates the last trade when first launched.
@@ -32,7 +32,7 @@ Subscribe to the following events emmited:
     // on intentional disconnect
     <ticker instance>.on("disconnecting", (tickerProvider) => {...});
 
-    // when server closed connection and WebsocketTicker tries to reconnect
+    // when server closed connection and TickerProvider tries to reconnect
     <ticker instance>.on("heartbeattimeout", (tickerProvider) => {...});
 
 TODO:
@@ -47,7 +47,7 @@ TODO:
 */
 
 const ulog = require("ulog");
-const log = ulog("WebsocketTicker");
+const log = ulog("TickerProvider");
 const WebSocket = require("ws");
 const Pusher = require("pusher-js");
 const EventEmitter = require("events");
@@ -70,7 +70,7 @@ const PROVIDER_TYPES = {
     PUSHER: "pusher"
 };
 
-class WebsocketTicker extends EventEmitter {
+class TickerProvider extends EventEmitter {
     constructor(definition) {
         super();
         this.isDisconnecting = false; // to restart connection if it's closed by server
@@ -407,4 +407,4 @@ class WebsocketTicker extends EventEmitter {
     }
 }
 
-module.exports = WebsocketTicker;
+module.exports = TickerProvider;

--- a/src/tickerProviders/bitfinexTickerProvider.js
+++ b/src/tickerProviders/bitfinexTickerProvider.js
@@ -34,16 +34,22 @@ const definition = {
                 tradeId: tradeData[0]
             };
         }
+
         const data = JSON.parse(msg.data);
+
         switch (data.event) {
         case "info":
             return { type: WebsocketTicker.MESSAGE_TYPES.CONNECTED, data };
+
         case "subscribed":
             return { type: WebsocketTicker.MESSAGE_TYPES.SUBSCRIBED, data };
+
         case "unsubscribed":
             return { type: WebsocketTicker.MESSAGE_TYPES.UNSUBSCRIBED, data };
+
         case "pong":
             return { type: WebsocketTicker.MESSAGE_TYPES.PONG, data };
+
         default:
             if (data[1] === "hb") {
                 return { type: WebsocketTicker.MESSAGE_TYPES.HEARTBEAT, data };
@@ -51,7 +57,7 @@ const definition = {
                 // confirmed trade with tradeid
                 // https://docs.bitfinex.com/v2/reference#ws-public-trades
                 return {
-                    type: WebsocketTicker.MESSAGE_TYPES.TRADE,
+                    type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
                     data: parseBitFinexTrade(data[2])
                 };
             } else if (Number.isInteger(data[0]) && Array.isArray(data[1]) && Array.isArray(data[1][0])) {
@@ -60,7 +66,7 @@ const definition = {
                 const lastTradeId = Math.max.apply(Math, data[1].map(o => o[0]));
                 const lastTrade = data[1].find(o => o[0] === lastTradeId);
                 return {
-                    type: WebsocketTicker.MESSAGE_TYPES.TRADE,
+                    type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
                     data: parseBitFinexTrade(lastTrade)
                 };
             } else if (data[1] === "te") {

--- a/src/tickerProviders/bitfinexTickerProvider.js
+++ b/src/tickerProviders/bitfinexTickerProvider.js
@@ -4,7 +4,7 @@ https://docs.bitfinex.com/v2/reference#ws-public-trades
 
 NB: not used b/c bitfinex price is out by ca. 3% https://www.reddit.com/r/CryptoCurrency/comments/abvbwd/why_is_btc_price_on_bitfinex_so_much_higher_than/
 */
-const WebsocketTicker = require("./WebsocketTicker.js");
+const TickerProvider = require("./TickerProvider.js");
 
 const definition = {
     NAME: "BITFINEX",
@@ -39,25 +39,25 @@ const definition = {
 
         switch (data.event) {
         case "info":
-            return { type: WebsocketTicker.MESSAGE_TYPES.CONNECTED, data };
+            return { type: TickerProvider.MESSAGE_TYPES.CONNECTED, data };
 
         case "subscribed":
-            return { type: WebsocketTicker.MESSAGE_TYPES.SUBSCRIBED, data };
+            return { type: TickerProvider.MESSAGE_TYPES.SUBSCRIBED, data };
 
         case "unsubscribed":
-            return { type: WebsocketTicker.MESSAGE_TYPES.UNSUBSCRIBED, data };
+            return { type: TickerProvider.MESSAGE_TYPES.UNSUBSCRIBED, data };
 
         case "pong":
-            return { type: WebsocketTicker.MESSAGE_TYPES.PONG, data };
+            return { type: TickerProvider.MESSAGE_TYPES.PONG, data };
 
         default:
             if (data[1] === "hb") {
-                return { type: WebsocketTicker.MESSAGE_TYPES.HEARTBEAT, data };
+                return { type: TickerProvider.MESSAGE_TYPES.HEARTBEAT, data };
             } else if (data[1] === "tu") {
                 // confirmed trade with tradeid
                 // https://docs.bitfinex.com/v2/reference#ws-public-trades
                 return {
-                    type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
+                    type: TickerProvider.MESSAGE_TYPES.TICKER_UPDATE,
                     data: parseBitFinexTrade(data[2])
                 };
             } else if (Number.isInteger(data[0]) && Array.isArray(data[1]) && Array.isArray(data[1][0])) {
@@ -66,15 +66,15 @@ const definition = {
                 const lastTradeId = Math.max.apply(Math, data[1].map(o => o[0]));
                 const lastTrade = data[1].find(o => o[0] === lastTradeId);
                 return {
-                    type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
+                    type: TickerProvider.MESSAGE_TYPES.TICKER_UPDATE,
                     data: parseBitFinexTrade(lastTrade)
                 };
             } else if (data[1] === "te") {
                 // trade update: "te" (executon) -  comes before tu (confirmed trade  w tradeid).
                 // we igndore it
-                return { type: WebsocketTicker.MESSAGE_TYPES.IGNORE, data };
+                return { type: TickerProvider.MESSAGE_TYPES.IGNORE, data };
             } else {
-                return { type: WebsocketTicker.MESSAGE_TYPES.UNKNOWN, data };
+                return { type: TickerProvider.MESSAGE_TYPES.UNKNOWN, data };
             }
         }
     }

--- a/src/tickerProviders/bitstampTickerProvider.js
+++ b/src/tickerProviders/bitstampTickerProvider.js
@@ -3,7 +3,7 @@
  https://docs.pro.coinbase.com/?r=1#the-ticker-channel
 */
 const fetch = require("node-fetch");
-const WebsocketTicker = require("./WebsocketTicker.js");
+const TickerProvider = require("./TickerProvider.js");
 
 // used for initial fetch because kraken doesn't return snapshot when first subscribed.
 // Ie. we need to fetch trades after connection to update lastTicker otherwise we would only have price after a trade
@@ -14,14 +14,14 @@ const definition = {
     PUSHER_APP_KEY: "de504dc5763aeef9ff52",
     PUSHER_CHANNEL_NAME: "live_trades_etheur", // live_trades_etheur
     PUSHER_CHANNEL_EVENT_NAME: "trade",
-    // HEARTBEAT_TIMEOUT: null, // WebsocketTicker sets it to pusherSocket.config.activity_timeout + 60s
+    // HEARTBEAT_TIMEOUT: null, // TickerProvider sets it to pusherSocket.config.activity_timeout + 60s
     // WSS_URL: null,
     // SUBSCRIBE_PAYLOAD: null,
     // UNSUBSCRIBE_PAYLOAD: null,
 
     processMessage: msg => {
         return {
-            type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
+            type: TickerProvider.MESSAGE_TYPES.TICKER_UPDATE,
             data: {
                 price: parseFloat(msg.price),
                 volume: msg.amount,

--- a/src/tickerProviders/bitstampTickerProvider.js
+++ b/src/tickerProviders/bitstampTickerProvider.js
@@ -21,7 +21,7 @@ const definition = {
 
     processMessage: msg => {
         return {
-            type: WebsocketTicker.MESSAGE_TYPES.TRADE,
+            type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
             data: {
                 price: parseFloat(msg.price),
                 volume: msg.amount,

--- a/src/tickerProviders/gdaxTickerProvider.js
+++ b/src/tickerProviders/gdaxTickerProvider.js
@@ -2,7 +2,7 @@
  https://docs.pro.coinbase.com/#get-product-ticker
  https://docs.pro.coinbase.com/?r=1#the-ticker-channel
 */
-const WebsocketTicker = require("./WebsocketTicker.js");
+const TickerProvider = require("./TickerProvider.js");
 
 const definition = {
     NAME: "GDAX",
@@ -22,7 +22,7 @@ const definition = {
         const data = JSON.parse(msg.data);
         switch (data.type) {
         case "error":
-            return { type: WebsocketTicker.MESSAGE_TYPES.ERROR, data };
+            return { type: TickerProvider.MESSAGE_TYPES.ERROR, data };
 
         case "ticker": {
             // GDAX returns a price without volume & time right after subscribe
@@ -30,7 +30,7 @@ const definition = {
             const time = data.time ? new Date(data.time) : new Date();
 
             return {
-                type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
+                type: TickerProvider.MESSAGE_TYPES.TICKER_UPDATE,
                 data: {
                     price: parseFloat(data.price),
                     volume,
@@ -42,16 +42,16 @@ const definition = {
 
         case "subscriptions":
             if (data.channels && data.channels.length > 0) {
-                return { type: WebsocketTicker.MESSAGE_TYPES.SUBSCRIBED, data };
+                return { type: TickerProvider.MESSAGE_TYPES.SUBSCRIBED, data };
             } else {
-                return { type: WebsocketTicker.MESSAGE_TYPES.UNSUBSCRIBED, data };
+                return { type: TickerProvider.MESSAGE_TYPES.UNSUBSCRIBED, data };
             }
 
         case "heartbeat":
-            return { type: WebsocketTicker.MESSAGE_TYPES.HEARTBEAT, data };
+            return { type: TickerProvider.MESSAGE_TYPES.HEARTBEAT, data };
 
         default:
-            return { type: WebsocketTicker.MESSAGE_TYPES.UNKNOWN, data };
+            return { type: TickerProvider.MESSAGE_TYPES.UNKNOWN, data };
         }
     }
 };

--- a/src/tickerProviders/gdaxTickerProvider.js
+++ b/src/tickerProviders/gdaxTickerProvider.js
@@ -30,7 +30,7 @@ const definition = {
             const time = data.time ? new Date(data.time) : new Date();
 
             return {
-                type: WebsocketTicker.MESSAGE_TYPES.TRADE,
+                type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
                 data: {
                     price: parseFloat(data.price),
                     volume,

--- a/src/tickerProviders/krakenTickerProvider.js
+++ b/src/tickerProviders/krakenTickerProvider.js
@@ -4,7 +4,7 @@
   https://www.kraken.com/features/api#get-ticker-info
 */
 const fetch = require("node-fetch");
-const WebsocketTicker = require("./WebsocketTicker.js");
+const TickerProvider = require("./TickerProvider.js");
 
 // used for initial fetch because kraken doesn't return snapshot when first subscribed.
 // Ie. we need to fetch trades after connection to update lastTicker otherwise we would only have price after a trade
@@ -32,25 +32,25 @@ const definition = {
         const data = JSON.parse(msg.data);
         switch (data.event) {
         case "systemStatus":
-            return { type: WebsocketTicker.MESSAGE_TYPES.CONNECTED, data };
+            return { type: TickerProvider.MESSAGE_TYPES.CONNECTED, data };
         case "subscriptionStatus":
             if (data.status === "subscribed") {
-                return { type: WebsocketTicker.MESSAGE_TYPES.SUBSCRIBED, data };
+                return { type: TickerProvider.MESSAGE_TYPES.SUBSCRIBED, data };
             } else if (data.status === "unsubscribed") {
-                return { type: WebsocketTicker.MESSAGE_TYPES.UNSUBSCRIBED, data };
+                return { type: TickerProvider.MESSAGE_TYPES.UNSUBSCRIBED, data };
             } else {
-                return { type: WebsocketTicker.MESSAGE_TYPES.UNKNOWN, data };
+                return { type: TickerProvider.MESSAGE_TYPES.UNKNOWN, data };
             }
         case "heartbeat":
-            return { type: WebsocketTicker.MESSAGE_TYPES.HEARTBEAT, data };
+            return { type: TickerProvider.MESSAGE_TYPES.HEARTBEAT, data };
         default:
             if ("event" in data) {
-                return { type: WebsocketTicker.MESSAGE_TYPES.UNKNOWN, data };
+                return { type: TickerProvider.MESSAGE_TYPES.UNKNOWN, data };
             } else {
                 // It's a ticker because no event prop present
                 // https://www.kraken.com/features/websocket-api#message-ticker
                 return {
-                    type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
+                    type: TickerProvider.MESSAGE_TYPES.TICKER_UPDATE,
                     data: { price: parseFloat(data[1].c[0]), volume: parseFloat(data[1].c[1]), time: new Date() } // Kraken doesn't return trade time nor seq
                 };
             }

--- a/src/tickerProviders/krakenTickerProvider.js
+++ b/src/tickerProviders/krakenTickerProvider.js
@@ -50,7 +50,7 @@ const definition = {
                 // It's a ticker because no event prop present
                 // https://www.kraken.com/features/websocket-api#message-ticker
                 return {
-                    type: WebsocketTicker.MESSAGE_TYPES.TRADE,
+                    type: WebsocketTicker.MESSAGE_TYPES.TICKER_UPDATE,
                     data: { price: parseFloat(data[1].c[0]), volume: parseFloat(data[1].c[1]), time: new Date() } // Kraken doesn't return trade time nor seq
                 };
             }

--- a/test/ratesfeeder.js
+++ b/test/ratesfeeder.js
@@ -7,6 +7,8 @@ const baseHelpers = require("./helpers/base.js");
 const CCY = "EUR";
 let BYTES_CCY;
 
+const getStatus = () => "tickerProvider mock getStatus for test";
+
 let ratesFeeder;
 
 describe("RatesFeeder: real exchange rate tests", () => {
@@ -20,7 +22,8 @@ describe("RatesFeeder: real exchange rate tests", () => {
         const tickers = [
             { lastTicker: { price: 187.73 } },
             { lastTicker: { price: 186.73 } },
-            { lastTicker: { price: 187.3 } }
+            { lastTicker: { price: 187.3 } },
+            getStatus
         ];
         const expectedPrice = 187.3;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
@@ -31,7 +34,8 @@ describe("RatesFeeder: real exchange rate tests", () => {
         const tickers = [
             { lastTicker: { price: 170.81 } },
             { lastTicker: { price: 171.06 } },
-            { lastTicker: { price: 0.1 } }
+            { lastTicker: { price: 0.1 } },
+            getStatus
         ];
         const expectedPrice = 170.81;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
@@ -42,7 +46,8 @@ describe("RatesFeeder: real exchange rate tests", () => {
         const tickers = [
             { lastTicker: { price: 176.79 } },
             { lastTicker: { price: null } },
-            { lastTicker: { price: 176.99 } }
+            { lastTicker: { price: 176.99 } },
+            getStatus
         ];
         const expectedPrice = 176.89;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
@@ -53,7 +58,8 @@ describe("RatesFeeder: real exchange rate tests", () => {
         const tickers = [
             { lastTicker: { price: 641.12 } },
             { lastTicker: { price: null } },
-            { lastTicker: { price: 0 } }
+            { lastTicker: { price: 0 } },
+            getStatus
         ];
         const expectedPrice = 641.12;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
@@ -72,9 +78,9 @@ describe("RatesFeeder: real exchange rate tests", () => {
         const expectedCheckedAt = new Date();
 
         ratesFeeder.tickers = [
-            { name: "testTicker1", lastTicker: { price: 657.62, time: expectedCheckedAt } },
-            { name: "testTicker2", lastTicker: { price: 659.52, time: expectedCheckedAt } },
-            { name: "testTicker3", lastTicker: { price: 659.2, time: expectedCheckedAt } }
+            { name: "testTicker1", lastTicker: { price: 657.62, time: expectedCheckedAt }, getStatus },
+            { name: "testTicker2", lastTicker: { price: 659.52, time: expectedCheckedAt }, getStatus },
+            { name: "testTicker3", lastTicker: { price: 659.2, time: expectedCheckedAt }, getStatus }
         ];
 
         const expectedPrice = 659.2;

--- a/test/ratesfeeder.js
+++ b/test/ratesfeeder.js
@@ -18,9 +18,9 @@ describe("RatesFeeder: real exchange rate tests", () => {
 
     it("ratesFeeder should return the median price of all tickers", () => {
         const tickers = [
-            { lastTrade: { price: 187.73 } },
-            { lastTrade: { price: 186.73 } },
-            { lastTrade: { price: 187.3 } }
+            { lastTicker: { price: 187.73 } },
+            { lastTicker: { price: 186.73 } },
+            { lastTicker: { price: 187.3 } }
         ];
         const expectedPrice = 187.3;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
@@ -29,9 +29,9 @@ describe("RatesFeeder: real exchange rate tests", () => {
 
     it("ratesFeeder should return the median price of all tickers (flash crash)", () => {
         const tickers = [
-            { lastTrade: { price: 170.81 } },
-            { lastTrade: { price: 171.06 } },
-            { lastTrade: { price: 0.1 } }
+            { lastTicker: { price: 170.81 } },
+            { lastTicker: { price: 171.06 } },
+            { lastTicker: { price: 0.1 } }
         ];
         const expectedPrice = 170.81;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
@@ -40,9 +40,9 @@ describe("RatesFeeder: real exchange rate tests", () => {
 
     it("ratesFeeder should return the median price of live tickers (1 ticker null)", () => {
         const tickers = [
-            { lastTrade: { price: 176.79 } },
-            { lastTrade: { price: null } },
-            { lastTrade: { price: 176.99 } }
+            { lastTicker: { price: 176.79 } },
+            { lastTicker: { price: null } },
+            { lastTicker: { price: 176.99 } }
         ];
         const expectedPrice = 176.89;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
@@ -50,14 +50,18 @@ describe("RatesFeeder: real exchange rate tests", () => {
     });
 
     it("ratesFeeder should return the median price of live tickers (2 ticker null/0)", () => {
-        const tickers = [{ lastTrade: { price: 641.12 } }, { lastTrade: { price: null } }, { lastTrade: { price: 0 } }];
+        const tickers = [
+            { lastTicker: { price: 641.12 } },
+            { lastTicker: { price: null } },
+            { lastTicker: { price: 0 } }
+        ];
         const expectedPrice = 641.12;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
         assert.equal(price, expectedPrice);
     });
 
     it("ratesFeeder should return null median price when all tickers null or zero )", () => {
-        const tickers = [{ lastTrade: { price: 0 } }, { lastTrade: { price: null } }, { lastTrade: { price: 0 } }];
+        const tickers = [{ lastTicker: { price: 0 } }, { lastTicker: { price: null } }, { lastTicker: { price: 0 } }];
         const expectedPrice = null;
         const price = ratesFeeder.calculateAugmintPrice(tickers);
         assert.equal(price, expectedPrice);
@@ -68,9 +72,9 @@ describe("RatesFeeder: real exchange rate tests", () => {
         const expectedCheckedAt = new Date();
 
         ratesFeeder.tickers = [
-            { name: "testTicker1", lastTrade: { price: 657.62, time: expectedCheckedAt } },
-            { name: "testTicker2", lastTrade: { price: 659.52, time: expectedCheckedAt } },
-            { name: "testTicker3", lastTrade: { price: 659.2, time: expectedCheckedAt } }
+            { name: "testTicker1", lastTicker: { price: 657.62, time: expectedCheckedAt } },
+            { name: "testTicker2", lastTicker: { price: 659.52, time: expectedCheckedAt } },
+            { name: "testTicker3", lastTicker: { price: 659.2, time: expectedCheckedAt } }
         ];
 
         const expectedPrice = 659.2;

--- a/test/ratesfeeder.js
+++ b/test/ratesfeeder.js
@@ -102,12 +102,18 @@ describe("RatesFeeder: real exchange rate tests", () => {
 
         const newStoredRate = await ratesFeeder.augmintRatesInstance.methods.rates(BYTES_CCY).call();
 
-        // lastTickerCheckResult format:
-        // lastTickerCheckResult{ CCY:  { currentAugmintRate: {price, lastUpdated},  livePrice, livePriceDifference, [tickersInfo] } };
-        // TODO: we should revise when we update this in checkTickerPrice() and then align the test
-        //assert.equal(ratesFeeder.lastTickerCheckResult[CCY].currentAugmintRate.price, expectedPrice);
-        // ratesFeeder.lastTickerCheckResult[CCY].currentAugmintRate.lastUpdated
         assert.equal(ratesFeeder.lastTickerCheckResult[CCY].livePrice, expectedPrice);
+        // lastTickerCheckResult format: { CCY:  { currentAugmintRate: {price, lastUpdated},  livePrice, livePriceDifference, [tickersInfo] } };
+        // currentAugmintRate shouldn't be updated yet (checkTickerPrice sends setRate async, currentAugmintRate updated
+        //                                              only after tx confirmation when checkTickerPrice called again)
+        assert.equal(
+            ratesFeeder.lastTickerCheckResult[CCY].currentAugmintRate.price,
+            prevStoredRate.rate / ratesFeeder.decimalsDiv
+        );
+        assert.equal(
+            ratesFeeder.lastTickerCheckResult[CCY].currentAugmintRate.lastUpdated / 1000,
+            prevStoredRate.lastUpdated
+        );
 
         assert.isAtLeast(ratesFeeder.lastTickerCheckResult.checkedAt - expectedCheckedAt, 0);
         assert.isAtMost(ratesFeeder.lastTickerCheckResult.checkedAt - expectedCheckedAt, 1000);
@@ -119,7 +125,7 @@ describe("RatesFeeder: real exchange rate tests", () => {
 
     it("ratesFeeder should NOT set the price on-chain from tickers when diff < threshold ");
 
-    it("ratesFeeder should NOT set the price on-chain from tickers when all tickers are down");
+    it("ratesFeeder should NOT set the price on-chain from tickers when all tickers are down", async () => {});
 
     it("set on-chain rate and should be the same", async () => {
         const price = 213.14;


### PR DESCRIPTION
- added `lastHeartbeat`, `connectedAt` and `reconnectCount` to ticker status info
- renamed trade to ticker in internal and status structs (as it can be either a ticker or last trade depending on provider API)
- renamed WebsocketTicker class to TickerProvider
