### PR TITLE
Gdax reconnect count fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "utf-8-validate": "5.0.2"
   },
   "scripts": {
-    "start": "yarn cross-env NODE_ENV=development node ./src/runFeeder.js",
-    "start:production": "yarn cross-env NODE_ENV=production node ./src/runFeeder.js",
-    "test": "yarn cross-env NODE_ENV=test mocha --timeout 10000 --exit",
+    "start": "yarn cross-env NODE_ENV=development NODE_PATH=. node ./src/runFeeder.js",
+    "start:production": "yarn cross-env NODE_ENV=production NODE_PATH=. node ./src/runFeeder.js",
+    "test": "yarn cross-env NODE_ENV=test NODE_PATH=. mocha --timeout 10000 --exit",
     "contracts:migrate": "cd augmint-contracts && yarn migrate",
     "ganache:run": "cd augmint-contracts && yarn ganache:run",
     "contracts:runmigrate": "cd augmint-contracts && yarn runmigrate"

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -15,13 +15,12 @@ TODO:
         web3.eth.transactionPollingTimeout: ${web3.eth.transactionPollingTimeout}
 */
 
-require("./env.js");
-const ulog = require("ulog");
-const log = ulog("ratesFeeder");
+require("src/env.js");
+const log = require("src/log.js")("ratesFeeder");
 const Web3 = require("web3");
-const contractsHelper = require("./contractsHelper.js");
-const TokenAEur = require("./abiniser/abis/TokenAEur_ABI_2ea91d34a7bfefc8f38ef0e8a5ae24a5.json");
-const Rates = require("./abiniser/abis/Rates_ABI_73a17ebb0acc71773371c6a8e1c8e6ce.json");
+const contractsHelper = require("src/contractsHelper.js");
+const TokenAEur = require("src/abiniser/abis/TokenAEur_ABI_2ea91d34a7bfefc8f38ef0e8a5ae24a5.json");
+const Rates = require("src/abiniser/abis/Rates_ABI_73a17ebb0acc71773371c6a8e1c8e6ce.json");
 
 const CCY = "EUR"; // only EUR is suported by TickerProvider providers ATM
 const SET_RATE_GAS_LIMIT = 80000;

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -320,7 +320,7 @@ class RatesFeeder {
     }
 
     exit(signal) {
-        log.info(`\n*** ratesFeeder Received ${signal}. Stopping.`);
+        log.info(`*** ratesFeeder Received ${signal}. Stopping.`);
         this.stop();
     }
 

--- a/src/log.js
+++ b/src/log.js
@@ -1,0 +1,4 @@
+const ulog = require("ulog");
+const log = moduleName => ulog(moduleName);
+
+module.exports = log;

--- a/src/runFeeder.js
+++ b/src/runFeeder.js
@@ -1,9 +1,8 @@
-require("./env.js");
-const ulog = require("ulog");
-const log = ulog("runFeeder");
-const RatesFeeder = require("../src/RatesFeeder.js");
-const subscribeTickers = require("../src/subscribeTickers.js");
-const statusApi = require("../src/statusApi/server.js");
+require("src/env.js");
+const log = require("src/log.js")("runFeeder");
+const RatesFeeder = require("src/RatesFeeder.js");
+const subscribeTickers = require("src/subscribeTickers.js");
+const statusApi = require("src/statusApi/server.js");
 
 log.info(
     `** runFeeder starting with settings:

--- a/src/statusApi/app.js
+++ b/src/statusApi/app.js
@@ -1,6 +1,5 @@
-require("../env.js");
-// const ulog = require("ulog");
-// const log = ulog("statusApi");
+require("src/env.js");
+// const log = require("src/log.js")("statusApi");
 
 const httplogger = require("morgan");
 const createError = require("http-errors");

--- a/src/statusApi/server.js
+++ b/src/statusApi/server.js
@@ -1,6 +1,5 @@
 require("../env.js");
-const ulog = require("ulog");
-const log = ulog("statusApi");
+const log = require("src/log.js")("statusApi");
 const app = require("./app.js");
 const http = require("http");
 let httpServer;

--- a/src/subscribeTickers.js
+++ b/src/subscribeTickers.js
@@ -2,11 +2,11 @@
  - write integration tests
   */
 
-const TickerProvider = require("./tickerProviders/TickerProvider.js");
+const TickerProvider = require("src/tickerProviders/TickerProvider.js");
 
-const gdaxTickerProvider = require("./tickerProviders/gdaxTickerProvider.js");
-const krakenTickerProvider = require("./tickerProviders/krakenTickerProvider.js");
-const bitstampTickerProvider = require("./tickerProviders/bitstampTickerProvider.js");
+const gdaxTickerProvider = require("src/tickerProviders/gdaxTickerProvider.js");
+const krakenTickerProvider = require("src/tickerProviders/krakenTickerProvider.js");
+const bitstampTickerProvider = require("src/tickerProviders/bitstampTickerProvider.js");
 // Not using bitfinex as price is out by ca. 3% https://www.reddit.com/r/CryptoCurrency/comments/abvbwd/why_is_btc_price_on_bitfinex_so_much_higher_than/
 //const bitfinexTickerProvider = require("./tickerProviders/bitfinexTickerProvider.js");
 

--- a/src/tickerProviders/TickerProvider.js
+++ b/src/tickerProviders/TickerProvider.js
@@ -408,7 +408,7 @@ class TickerProvider extends EventEmitter {
     }
 
     _exit(signal) {
-        log.info(`\n*** ${this.name} received ${signal}. Disconnecting.`);
+        log.info(`*** ${this.name} received ${signal}. Disconnecting.`);
         this.disconnect();
     }
 

--- a/src/tickerProviders/TickerProvider.js
+++ b/src/tickerProviders/TickerProvider.js
@@ -45,9 +45,7 @@ TODO:
 - BitStamp released V2 websocket API which is without pusher - we could get rid of pusher specific code
 
 */
-
-const ulog = require("ulog");
-const log = ulog("TickerProvider");
+const log = require("src/log.js")("TickerProvider");
 const WebSocket = require("ws");
 const Pusher = require("pusher-js");
 const EventEmitter = require("events");


### PR DESCRIPTION
- fix an issue that `reconnectAt` and `reconnectCount` weren't shown in status for GDAX
- finess node `require` paths
- move logging to a common file (so that formatting can be applied later in a single place)