### PR TITLE
Provider tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "chai": "4.2.0",
-    "mocha": "6.0.2"
+    "mocha": "6.0.2",
+    "sinon": "7.2.7"
   },
   "optionalDependencies": {
     "bufferutil": "4.0.1",

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -18,7 +18,7 @@ TODO:
 require("src/env.js");
 const log = require("src/log.js")("ratesFeeder");
 const Web3 = require("web3");
-const contractsHelper = require("src/contractsHelper.js");
+const contractsHelper = require("src/helpers/contractsHelper.js");
 const TokenAEur = require("src/abiniser/abis/TokenAEur_ABI_2ea91d34a7bfefc8f38ef0e8a5ae24a5.json");
 const Rates = require("src/abiniser/abis/Rates_ABI_73a17ebb0acc71773371c6a8e1c8e6ce.json");
 

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -17,6 +17,7 @@ TODO:
 
 require("src/env.js");
 const log = require("src/log.js")("ratesFeeder");
+const sigintHandler = require("src/helpers/sigintHandler.js");
 const Web3 = require("web3");
 const contractsHelper = require("src/helpers/contractsHelper.js");
 const promiseTimeout = require("src/helpers/promiseTimeout.js");
@@ -60,7 +61,7 @@ class RatesFeeder {
     }
 
     async init() {
-        ["SIGINT", "SIGHUP", "SIGTERM"].forEach(signal => process.on(signal, signal => this.exit(signal)));
+        sigintHandler(this.exit.bind(this), "RatesFeeder");
 
         this.account = process.env.ETHEREUM_ACCOUNT;
 
@@ -291,7 +292,7 @@ class RatesFeeder {
         }
     }
 
-    stop() {
+    async stop() {
         clearTimeout(this.checkTickerPriceTimer);
         if (
             this.web3 &&
@@ -299,13 +300,13 @@ class RatesFeeder {
             typeof this.web3.currentProvider.connection.close === "function"
         ) {
             // connection.close only exists when websocket connection. it is required to close in order node process to stop
-            this.web3.currentProvider.connection.close();
+            await this.web3.currentProvider.connection.close();
         }
     }
 
-    exit(signal) {
+    async exit(signal) {
         log.info(`*** ratesFeeder Received ${signal}. Stopping.`);
-        this.stop();
+        await this.stop();
     }
 
     getStatus() {

--- a/src/helpers/contractsHelper.js
+++ b/src/helpers/contractsHelper.js
@@ -22,12 +22,12 @@ async function connectLatest(web3, abiFile) {
 }
 
 function getDeploysFile(networkId, contractName) {
-    const deploysFileName = `./abiniser/deployments/${networkId}/${contractName}_DEPLOYS.json`;
+    const deploysFileName = `src/abiniser/deployments/${networkId}/${contractName}_DEPLOYS.json`;
     let deploysFile;
 
     try {
         /* must provide fileName string again for webpack (needs to be statically analysable) */
-        deploysFile = require(`./abiniser/deployments/${networkId}/${contractName}_DEPLOYS.json`);
+        deploysFile = require(`src/abiniser/deployments/${networkId}/${contractName}_DEPLOYS.json`);
     } catch (error) {
         throw new Error(`Couldn't import deployment file ${deploysFileName} for ${contractName}\n${error}`);
     }

--- a/src/helpers/promiseTimeout.js
+++ b/src/helpers/promiseTimeout.js
@@ -1,0 +1,15 @@
+module.exports = promiseTimeout;
+
+function promiseTimeout(ms, promise) {
+    let id;
+    let timeout = new Promise((resolve, reject) => {
+        id = setTimeout(() => {
+            reject("Timed out in " + ms + "ms.");
+        }, ms);
+    });
+
+    return Promise.race([promise, timeout]).then(result => {
+        clearTimeout(id);
+        return result;
+    });
+}

--- a/src/helpers/sigintHandler.js
+++ b/src/helpers/sigintHandler.js
@@ -1,0 +1,17 @@
+module.exports = sigintHandler;
+const log = require("src/log.js")("sigintHandler");
+const promiseTimeout = require("src/helpers/promiseTimeout.js");
+const DEFAULT_EXIT_TIMEOUT = 10000; // how much to wait before timing out disconnect (in ms)
+
+function sigintHandler(exitHandler, name) {
+    ["SIGINT", "SIGQUIT", "SIGTERM"].forEach(signal => {
+        process.on(signal, async signal => {
+            await promiseTimeout(DEFAULT_EXIT_TIMEOUT, exitHandler(signal)).catch(error => {
+                // most likely timeout
+                log.warn(name, "exit failed with Error: ", error);
+                process.exitCode = 999;
+            });
+            log.debug(name, "exit success");
+        });
+    });
+}

--- a/src/runFeeder.js
+++ b/src/runFeeder.js
@@ -16,33 +16,43 @@ statusApi.start(ratesFeeder);
 ratesFeeder
     .init()
 
-    .then(() => {
-        subscribeTickers.connectAll();
-
+    .then(async () => {
         subscribeTickers.tickers.forEach(tickerProvider => {
             // tickerProvider.on("pricechange", onTickerPriceChange);
             // tickerProvider.on("trade", onTickerTrade);
-            // tickerProvider.on("disconnecting", onTickerDisconnecting);
+            tickerProvider.on("connected", onTickerConnected);
+            tickerProvider.on("disconnecting", onTickerDisconnecting);
+            tickerProvider.on("disconnected", onTickerDisconnected);
             tickerProvider.on("heartbeattimeout", onTickerHeartbeatTimeout);
         });
 
-        // function onTickerDisconnecting(tickerProvider) {
-        //     log.debug(tickerProvider.name, "disconnecting.", "WebSocket readyState: ", tickerProvider.ws.readyState);
-        // }
-
-        function onTickerHeartbeatTimeout(ticker) {
-            log.warn(ticker.name, "heartbeat timed out. Reconnecting.");
-        }
-
-        // function onTickerPriceChange(newTicker, prevTicker, ticker) {
-        //     log.log("onTickerPriceChange", ticker.name, "\t", JSON.stringify(newTicker), JSON.stringify(prevTicker));
-        // }
-        //
-        // function onTickerTrade(newTicker, prevTicker, tickerProvider) {
-        //     log.debug("onTickerTrade", tickerProvider.name, "\t", JSON.stringify(newTicker), JSON.stringify(prevTicker));
-        // }
+        await subscribeTickers.connectAll();
     })
     .catch(error => {
         log.error("Error: Can't init ratesFeeder. Details:\n", error);
         process.exit(1);
     });
+
+function onTickerConnected(data, tickerProvider) {
+    log.info(tickerProvider.name, "connected.", data);
+}
+
+function onTickerDisconnecting(tickerProvider) {
+    log.debug(tickerProvider.name, "disconnecting.");
+}
+
+function onTickerDisconnected(tickerProvider) {
+    log.info(tickerProvider.name, "disconnected.");
+}
+
+function onTickerHeartbeatTimeout(ticker) {
+    log.warn(ticker.name, "heartbeat timed out. Reconnecting.");
+}
+
+// function onTickerPriceChange(newTicker, prevTicker, ticker) {
+//     log.log("onTickerPriceChange", ticker.name, "\t", JSON.stringify(newTicker), JSON.stringify(prevTicker));
+// }
+//
+// function onTickerTrade(newTicker, prevTicker, tickerProvider) {
+//     log.debug("onTickerTrade", tickerProvider.name, "\t", JSON.stringify(newTicker), JSON.stringify(prevTicker));
+// }

--- a/src/subscribeTickers.js
+++ b/src/subscribeTickers.js
@@ -17,8 +17,8 @@ const tickers = [
     //,    new TickerProvider(bitfinexTickerProvider.definition)
 ];
 
-function connectAll() {
-    tickers.forEach(ticker => ticker.connectAndSubscribe());
+async function connectAll() {
+    await Promise.all(tickers.map(ticker => ticker.connectAndSubscribe()));
 }
 
 module.exports = {

--- a/src/tickerProviders/TickerProvider.js
+++ b/src/tickerProviders/TickerProvider.js
@@ -263,6 +263,10 @@ class TickerProvider extends EventEmitter {
         clearTimeout(this.heartbeatTimeoutTimer);
         clearTimeout(this.pingIntervalTimer);
 
+        const returnPromise = new Promise(resolve => {
+            this.once("disconnected", () => resolve());
+        });
+
         switch (this.providerType) {
         case PROVIDER_TYPES.WSS:
             if (this.ws && this.ws.readyState === WebSocket.OPEN) {
@@ -289,9 +293,7 @@ class TickerProvider extends EventEmitter {
             log.error("Error:", this.name + "disconnect(). Invalid provider type: " + this.providerType);
         }
 
-        return new Promise(resolve => {
-            this.once("disconnected", () => resolve());
-        });
+        return returnPromise;
     }
 
     async reconnect() {

--- a/src/tickerProviders/TickerProvider.js
+++ b/src/tickerProviders/TickerProvider.js
@@ -22,7 +22,10 @@ constructor receives definition object :
     // see  example definition in *tickerProvider.js files implemented for a few exchanges
 }
 
-Subscribe to the following events emmited:
+Subscribe to the following events emitted:
+    // on connected:
+    <ticker instance>.on("connected", (info, tickerProvider) => { ... } );
+
     // on Every trade:
     <ticker instance>.on("trade", (newTicker, prevTicker, tickerProvider) => { ... } );
 
@@ -308,6 +311,7 @@ class TickerProvider extends EventEmitter {
         if (this.pingInterval && !this.isDisconnecting) {
             this.pingIntervalTimer = setInterval(this.ping.bind(this), this.pingInterval);
         }
+        this.emit("connected", data, this);
     }
 
     _onProviderDisconnected() {

--- a/test/rateProviders.js
+++ b/test/rateProviders.js
@@ -1,13 +1,63 @@
 /* TODO: Integration test with real rates provider feeds */
-//const assert = require("assert");
-// const baseHelpers = require("./helpers/base.js");
+const chai = require("chai");
+const assert = chai.assert;
+const sinon = require("sinon");
 
-describe.skip("rateProviders: test interfaces", function() {
-    before(async function() {});
+const TickerProvider = require("src/tickerProviders/TickerProvider.js");
 
-    it("Kraken interface should return a number", async function() {});
+const gdaxTickerProvider = require("src/tickerProviders/gdaxTickerProvider.js");
+let ticker;
 
-    it.skip("BitStamp interface should return a number", async function() {});
+describe("GDAX ticker provider tests", () => {
+    before(() => {
+        ticker = new TickerProvider(gdaxTickerProvider.definition);
+    });
 
-    it("Gdax interface should return a number", async function() {});
+    it("should have correct state before connect", () => {
+        const status = ticker.getStatus();
+        assert.equal(status.name, "GDAX");
+
+        assert(!status.isConnected);
+        assert.isNull(status.connectedAt);
+        assert.isNull(status.lastHeartbeat);
+        assert.isNull(status.reconnectCount);
+
+        assert.isNull(status.lastTicker);
+    });
+
+    it("should connect and have initial ticker", async () => {
+        // how to avoid ticker update triggering right after connect when websocket/pusher connected?
+        const connectedSpy = sinon.spy();
+        ticker.on("connected", connectedSpy);
+
+        await ticker.connectAndSubscribe();
+        assert(connectedSpy.calledOnce);
+
+        const connectionTime = new Date();
+        let status = ticker.getStatus();
+
+        assert.equal(status.name, "GDAX");
+        assert(status.isConnected);
+        assert(Math.abs(status.connectedAt - connectionTime < 3));
+        assert(Math.abs(status.lastHeartbeat - connectionTime) < 3);
+        assert.equal(status.reconnectCount, 0);
+
+        assert.isNumber(status.lastTicker.price);
+        assert(Math.abs(status.lastTicker.time - connectionTime) < 5);
+
+        const disconnectedSpy = sinon.spy();
+        const disconnectingSpy = sinon.spy();
+        ticker.on("disconnecting", disconnectingSpy);
+        ticker.on("disconnected", disconnectedSpy);
+
+        await ticker.disconnect();
+        assert(disconnectedSpy.calledOnce);
+        assert(disconnectingSpy.calledOnce);
+        status = ticker.getStatus();
+        assert(!status.isConnected);
+    });
+
+    it("should terminate for SIGINT");
+
+    it("should return ticker after ticker updated"); // how to mock ticker update?
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,35 @@
 # yarn lockfile v1
 
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.0.2", "@sinonjs/commons@^1.3.1":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.4.0.tgz#7b3ec2d96af481d7a0321252e7b1c94724ec5a78"
+  integrity sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.1.0", "@sinonjs/formatio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.1.tgz#52310f2f9bcbc67bdac18c94ad4901b95fde267e"
+  integrity sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.2.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.0.tgz#9557ea89cd39dbc94ffbd093c8085281cac87416"
+  integrity sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==
+  dependencies:
+    "@sinonjs/commons" "^1.0.2"
+    array-from "^2.1.1"
+    lodash "^4.17.11"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/node@^10.3.2":
   version "10.14.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.1.tgz#8701cd760acc20beba5ffe0b7a1b879f39cb8c41"
@@ -83,6 +112,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -777,7 +811,7 @@ detect-file@^1.0.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
   integrity sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
 
-diff@3.5.0:
+diff@3.5.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -1744,6 +1778,11 @@ is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1834,6 +1873,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 keccakjs@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/keccakjs/-/keccakjs-0.2.3.tgz#5e4e969ce39689a3861f445d7752ee3477f9fe72"
@@ -1892,6 +1936,16 @@ log-symbols@2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+lolex@^2.3.2:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
+  integrity sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==
+
+lolex@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-3.1.0.tgz#1a7feb2fefd75b3e3a7f79f0e110d9476e294434"
+  integrity sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==
 
 lowercase-keys@^1.0.0:
   version "1.0.1"
@@ -2137,9 +2191,9 @@ nan@2.10.0:
   integrity sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==
 
 nan@^2.0.8, nan@^2.3.3:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.0.tgz#7bdfc27dd3c060c46e60b62c72b74012d1a4cd68"
-  integrity sha512-5DDQvN0luhXdut8SCwzm/ZuAX2W+fwhqNzfq7CZ+OJzQ6NwpcqmIGyLD1R8MEt7BeErzcsI0JLr4pND2pNp2Cw==
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.1.tgz#a15bee3790bde247e8f38f1d446edcdaeb05f2dd"
+  integrity sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==
 
 nano-json-stream-parser@^0.1.2:
   version "0.1.2"
@@ -2172,6 +2226,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.10.tgz#ae46a09a26436fae91a38a60919356ae6db143b6"
+  integrity sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==
+  dependencies:
+    "@sinonjs/formatio" "^3.1.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
 
 node-environment-flags@1.0.4:
   version "1.0.4"
@@ -2343,9 +2408,9 @@ p-timeout@^1.1.1:
     p-finally "^1.0.0"
 
 p-try@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
-  integrity sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.1.0.tgz#c1a0f1030e97de018bb2c718929d2af59463e505"
+  integrity sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==
 
 parse-asn1@^5.0.0:
   version "5.1.4"
@@ -2401,6 +2466,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
 
 pathval@^1.1.0:
   version "1.1.0"
@@ -2864,6 +2936,19 @@ simple-get@^2.7.0:
     once "^1.3.1"
     simple-concat "^1.0.0"
 
+sinon@7.2.7:
+  version "7.2.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.2.7.tgz#ee90f83ce87d9a6bac42cf32a3103d8c8b1bfb68"
+  integrity sha512-rlrre9F80pIQr3M36gOdoCEWzFAMDgHYD8+tocqOw+Zw9OZ8F84a80Ds69eZfcjnzDqqG88ulFld0oin/6rG/g==
+  dependencies:
+    "@sinonjs/commons" "^1.3.1"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.2.0"
+    diff "^3.5.0"
+    lolex "^3.1.0"
+    nise "^1.4.10"
+    supports-color "^5.5.0"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -3043,7 +3128,7 @@ supports-color@6.0.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -3191,7 +3276,7 @@ tweetnacl@^1.0.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.1.tgz#2594d42da73cd036bd0d2a54683dd35a6b55ca17"
   integrity sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A==
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
- testing all providers  interfaces 

and some tweaks/refactor/fixes on the way:
- Promisified `connectAndSubscribe`, `disconnect`, `reconnect` and `subscribe` in `TickerProvider`
- Promisified `stop` in ``RatesFeeder` and `
- new `disconnected` and `initialtickerinforeceived` events from TickerProvider
- httpserver force closing sockets after a timeout (5sec) when `SIGINT` recevied
- moved `promiseTimeout` and `SIGINT` handling into helpers
- not catching `SIGHUP` anymore
- fixed Bitstamp disconnect timing issue