### PR TITLE
launch without yarn on heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yarn start:production
+web: NODE_PATH=. node ./src/runFeeder.js


### PR DESCRIPTION
start without yarn on heroku to avoid the process becoming a subprocess of  yarn.
hopefully it fixes some heroku dyno management issues, ie. shutdown by heroku generated some confusing  log entries, eg:
```
app[web.1]: Error waiting for process to terminate: No child processes
heroku[web.1]: Stopping all processes with SIGTERM
heroku[web.1]: Process exited with status 22
```