### PR TITLE
fix NewOrder event subscription dropping in prod after long runnning

### DIFF
--- a/.env
+++ b/.env
@@ -24,6 +24,9 @@ PROVIDER_URL = ws://localhost:8545/
 # NB: Infura project secret is not supported yet (web3js auth?), use address whitelisting if necessary
 # INFURA_PROJECT_ID =
 
+# how often check if ethereum connection is still alive? (workaround for web3 not detecting websocket connection loss)
+ETHEREUM_CONNECTION_CHECK_INTERVAL = 10000
+
 # log ethereum tx success with LOG level after how many confirmation
 LOG_AS_SUCCESS_AFTER_N_CONFIRMATION = 3
 

--- a/.env.test
+++ b/.env.test
@@ -3,12 +3,17 @@
 # see https://ulog.js.org/  modules: ratesFeeder, TickerProvider, statusApi
 LOG = ERROR
 
+# how often check if ethereum connection is still alive? (workaround for web3 not detecting websocket connection loss)
+ETHEREUM_CONNECTION_CHECK_INTERVAL = 0
+
+
 # how often compare live ticker prices to decide if Augmint on chain price needs to be updated (in ms). Set to 0 to disable (for tests)
 #    NB: ticker prices in state & updated "instantly" each time a trade made on the exchange (via websocket subscriptions )
 RATESFEEDER_CHECK_TICKER_PRICE_INTERVAL = 0
 
 # not to interfere with tests
 HTTP_POLL_INTERVAL = 0
+
 
 # when to update Augmint rate? A rate update tx will be sent to chain if live ticker price (avg) is lower/higher by this % than current Augmint rate
 # in % (i.e. 1 = 1%)

--- a/src/MatchMaker/MatchMaker.js
+++ b/src/MatchMaker/MatchMaker.js
@@ -43,7 +43,6 @@ class MatchMaker extends EventEmitter {
         if (!this.web3.utils.isAddress(this.account)) {
             throw new Error("Invalid MATCHMAKER_ETHEREUM_ACCOUNT: " + this.account);
         }
-        this.web3.eth.defaultAccount = this.account;
 
         if (this.ethereumConnection.isConnected) {
             await this.onEthereumConnected(); // connect event might be already triggered so we need to call it on init

--- a/src/MatchMaker/MatchMaker.js
+++ b/src/MatchMaker/MatchMaker.js
@@ -208,10 +208,19 @@ class MatchMaker extends EventEmitter {
     }
 
     async _subscribe() {
-        this.newOrderEventSubscription = this.exchangeInstance.events.NewOrder().on("data", this.onNewOrder.bind(this));
+        this.newOrderEventSubscription = this.exchangeInstance.events
+            .NewOrder()
+            .on("data", this.onNewOrder.bind(this))
+            .on("error", error => {
+                log.warn(" MatchMaker NewOrder subscription error:", error);
+            });
+
         this.orderFillEventSubscription = this.exchangeInstance.events
             .OrderFill()
-            .on("data", this.onOrderFill.bind(this));
+            .on("data", this.onOrderFill.bind(this))
+            .on("error", error => {
+                log.warn(" MatchMaker OrderFill subscription error:", error);
+            });
     }
 
     async _unsubscribe() {

--- a/src/MatchMaker/MatchMaker.js
+++ b/src/MatchMaker/MatchMaker.js
@@ -44,7 +44,7 @@ class MatchMaker extends EventEmitter {
             throw new Error("Invalid MATCHMAKER_ETHEREUM_ACCOUNT: " + this.account);
         }
 
-        if (this.ethereumConnection.isConnected) {
+        if (await this.ethereumConnection.isConnected()) {
             await this.onEthereumConnected(); // connect event might be already triggered so we need to call it on init
         }
 
@@ -223,11 +223,13 @@ class MatchMaker extends EventEmitter {
     }
 
     async _unsubscribe() {
-        if (this.newOrderEventSubscription && this.ethereumConnection.isConnected) {
+        if (this.newOrderEventSubscription) {
             await Promise.all([
                 this.newOrderEventSubscription.unsubscribe(),
                 this.orderFillEventSubscription.unsubscribe()
             ]);
+            this.newOrderEventSubscription = null;
+            this.orderFillEventSubscription = null;
         }
     }
 

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -72,7 +72,6 @@ class RatesFeeder {
         if (!this.web3.utils.isAddress(this.account)) {
             throw new Error("Invalid RATESFEEDER_ETHEREUM_ACCOUNT: " + this.account);
         }
-        this.web3.eth.defaultAccount = this.account;
 
         [this.augmintRatesInstance, this.augmintTokenInstance] = await Promise.all([
             contractConnection.connectLatest(this.ethereumConnection, Rates),

--- a/src/RatesFeeder.js
+++ b/src/RatesFeeder.js
@@ -119,7 +119,7 @@ class RatesFeeder {
                 );
             });
 
-            if (!this.ethereumConnection.isConnected) {
+            if (!(await this.ethereumConnection.isConnected())) {
                 log.debug("checkTickerPrice() - Ethereum is not connected. Skipping Augmint price check. ");
             } else {
                 const currentAugmintRate = await this.getAugmintRate(CCY);
@@ -287,14 +287,6 @@ class RatesFeeder {
     async stop() {
         this.isStopping = true;
         clearTimeout(this.checkTickerPriceTimer);
-        if (
-            this.web3 &&
-            this.web3.currentProvider.connection &&
-            typeof this.web3.currentProvider.connection.close === "function"
-        ) {
-            // connection.close only exists when websocket connection. it is required to close in order node process to stop
-            await this.web3.currentProvider.connection.close();
-        }
     }
 
     async exit(signal) {

--- a/src/augmintjs/Contract.js
+++ b/src/augmintjs/Contract.js
@@ -27,14 +27,14 @@ class Contract {
         return this.instance ? this.instance._address : null;
     }
 
-    connect(ethereumConnection, abiFile, address) {
+    async connect(ethereumConnection, abiFile, address) {
         if (address) {
             throw new Error(
                 "Connecting to a contract at arbitary address is not supported yet. Pass no address to connect latest contract deployment at network"
             );
         }
 
-        if (!ethereumConnection.isConnected) {
+        if (!(await ethereumConnection.isConnected())) {
             throw new Error(
                 "Contract: not connected to web3 at passed ethereumConnection. call ethereumConnection.connect first"
             );

--- a/src/augmintjs/Contract.test.js
+++ b/src/augmintjs/Contract.test.js
@@ -1,4 +1,5 @@
 const assert = require("chai").assert;
+const nodeAssert = require("assert");
 const Contract = require("./Contract.js");
 const EthereumConnection = require("./EthereumConnection.js");
 const ethereumConnection = new EthereumConnection();
@@ -12,16 +13,14 @@ describe("constructor", () => {
         assert.isNull(contract.address);
     });
 
-    it("should throw trying to connect without ethereumConnection", () => {
+    it("should throw trying to connect without ethereumConnection", async () => {
         const contract = new Contract();
 
-        assert.throws(
-            () =>
-                contract.connect(
-                    ethereumConnection,
-                    {}
-                ),
-            Error,
+        nodeAssert.rejects(
+            contract.connect(
+                ethereumConnection,
+                {}
+            ),
             /not connected to web3/
         );
     });

--- a/src/augmintjs/EthereumConnection.js
+++ b/src/augmintjs/EthereumConnection.js
@@ -161,7 +161,9 @@ class EthereumConnection extends EventEmitter {
 
         this.isTryingToReconnect = false;
 
-        this.connectionCheckTimer = setInterval(this._checkConnection.bind(this), this.CONNECTION_CHECK_INTERVAL);
+        if (this.CONNECTION_CHECK_INTERVAL > 0) {
+            this.connectionCheckTimer = setInterval(this._checkConnection.bind(this), this.CONNECTION_CHECK_INTERVAL);
+        }
 
         this.emit("connected", this);
     }
@@ -223,7 +225,7 @@ class EthereumConnection extends EventEmitter {
         // subscriptions are starting not to arrive on Infura websocket after a while and provider end is not always triggered
         //  TODO: - check if newer versions of web3 (newer than beta33) are handling webscoket connection drops correclty
         //        - make _tryToReconnect and _checkConnection one function and use only one timer?
-        if (!this.isStopping && !this.isTryingToReconnect) {
+        if (!this.isStopping && !this.isTryingToReconnect && !(await this.isConnected())) {
             log.debug(
                 " EthereumConnection _checkConnection() - ethereumConnection.isConnected() returned false. trying to reconnect"
             );

--- a/src/augmintjs/EthereumConnection.js
+++ b/src/augmintjs/EthereumConnection.js
@@ -161,7 +161,7 @@ class EthereumConnection extends EventEmitter {
 
         this.isTryingToReconnect = false;
 
-        this.connectionCheckTimer = setTimeout(this._checkConnection.bind(this), this.CONNECTION_CHECK_INTERVAL);
+        this.connectionCheckTimer = setInterval(this._checkConnection.bind(this), this.CONNECTION_CHECK_INTERVAL);
 
         this.emit("connected", this);
     }
@@ -220,12 +220,10 @@ class EthereumConnection extends EventEmitter {
     }
 
     async _checkConnection() {
-        // subscriptions are starting not to arrive on Infura websocket after a while.
+        // subscriptions are starting not to arrive on Infura websocket after a while and provider end is not always triggered
         //  TODO: - check if newer versions of web3 (newer than beta33) are handling webscoket connection drops correclty
         //        - make _tryToReconnect and _checkConnection one function and use only one timer?
-        if (await this.isConnected()) {
-            this.connectionCheckTimer = setTimeout(this._checkConnection.bind(this), this.CONNECTION_CHECK_INTERVAL);
-        } else if (!this.isStopping && !this.isTryingToReconnect) {
+        if (!this.isStopping && !this.isTryingToReconnect) {
             log.debug(
                 " EthereumConnection _checkConnection() - ethereumConnection.isConnected() returned false. trying to reconnect"
             );

--- a/src/augmintjs/EthereumConnection.test.js
+++ b/src/augmintjs/EthereumConnection.test.js
@@ -13,13 +13,13 @@ describe("EthereumConnection", () => {
         ethereumConnection.on("disconnected", disconnectedSpy);
         ethereumConnection.on("connectionLost", connectionLostSpy);
 
-        assert(!ethereumConnection.isConnected);
+        assert(!(await ethereumConnection.isConnected()));
 
         await ethereumConnection.connect();
 
         const expNetworkId = parseInt(await ethereumConnection.web3.eth.net.getId(), 10);
 
-        assert(ethereumConnection.isConnected);
+        assert(await ethereumConnection.isConnected());
         assert.equal(ethereumConnection.networkId, expNetworkId);
         assert(ethereumConnection.blockGasLimit > 0);
         assert(ethereumConnection.safeBlockGasLimit, Math.round(ethereumConnection.blockGasLimit * 0.9));
@@ -36,7 +36,7 @@ describe("EthereumConnection", () => {
 
         await ethereumConnection.stop();
 
-        assert(!ethereumConnection.isConnected);
+        assert(!(await ethereumConnection.isConnected()));
         assert(ethereumConnection.isStopping);
         assert(!ethereumConnection.isTryingToReconnect);
 

--- a/src/augmintjs/Exchange.js
+++ b/src/augmintjs/Exchange.js
@@ -63,7 +63,7 @@ class Exchange extends Contract {
     }
 
     async connect(ethereumConnection, exchangeAddress) {
-        super.connect(
+        await super.connect(
             ethereumConnection,
             ExchangeArtifact,
             exchangeAddress

--- a/test/helpers/base.js
+++ b/test/helpers/base.js
@@ -11,7 +11,7 @@ module.exports = {
         return ethereumConnection.web3;
     },
     ratesFeeder: async function() {
-        if (!ethereumConnection.isConnected) {
+        if (!(await ethereumConnection.isConnected())) {
             await ethereumConnection.connect();
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,16 +17,7 @@
     "@sinonjs/commons" "^1"
     "@sinonjs/samsam" "^3.1.0"
 
-"@sinonjs/samsam@^3.1.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.0.tgz#9557ea89cd39dbc94ffbd093c8085281cac87416"
-  integrity sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==
-  dependencies:
-    "@sinonjs/commons" "^1.0.2"
-    array-from "^2.1.1"
-    lodash "^4.17.11"
-
-"@sinonjs/samsam@^3.3.1":
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.1.tgz#e88c53fbd9d91ad9f0f2b0140c16c7c107fe0d07"
   integrity sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==
@@ -251,9 +242,9 @@ bluebird@^2.9.34:
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
 bluebird@^3.5.0:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
-  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
+  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
 
 bn.js@4.11.6:
   version "4.11.6"
@@ -444,9 +435,9 @@ cache-base@^1.0.1:
     unset-value "^1.0.0"
 
 camelcase@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.2.0.tgz#e7522abda5ed94cc0489e1b8466610e88404cf45"
-  integrity sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -539,9 +530,9 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
     delayed-stream "~1.0.0"
 
 commander@^2.8.1:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
-  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@~2.8.1:
   version "2.8.1"
@@ -2019,9 +2010,9 @@ media-typer@0.3.0:
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
 mem@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-4.2.0.tgz#5ee057680ed9cb8dad8a78d820f9a8897a102025"
-  integrity sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
+  integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
   dependencies:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
@@ -2082,9 +2073,9 @@ mime@1.4.1:
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
 mimic-fn@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.0.0.tgz#0913ff0b121db44ef5848242c38bbb35d44cabde"
-  integrity sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 mimic-response@^1.0.0:
   version "1.0.1"
@@ -2449,9 +2440,9 @@ p-timeout@^1.1.1:
     p-finally "^1.0.0"
 
 p-try@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.1.0.tgz#c1a0f1030e97de018bb2c718929d2af59463e505"
-  integrity sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parse-asn1@^5.0.0:
   version "5.1.4"


### PR DESCRIPTION
We are on beta33 and it has a lot of issues with websocket connections. Later versions allegedly fixed it but current latest beta52 doesn't work.

So this is a temp fix until [this web3.js issue](https://ethereum.stackexchange.com/questions/69343/sendtransaction-never-resolves-on-web3-js-1-0-0-beta49-beta52) is resolved and we can upgrade to beta52+

We need to revisit / refactor this reconnection (and resubscription) logic when we upgrade web3